### PR TITLE
Raft PR edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ The role defines variables in `defaults/main.yml`:
 
 ### Raft Storage Backend
 
+#### `vault_raft_group_name`
+
+- Inventory group name of servers hosting the raft backend
+- Default value: vault_raft_servers
+
 #### `vault_raft_data_path`
 
 - Data path for Raft

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,7 @@ vault_mysql_max_connection_lifetime: ""
 
 # raft storage settings
 vault_backend: raft
+vault_raft_group_name: "vault_raft_servers"
 vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
 vault_raft_node_id: "{{ lookup('env', 'VAULT_RAFT_NODE_ID') | default(inventory_hostname_short, true) }}" 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,7 @@ vault_main_configuration_template: vault_main_configuration.hcl.j2
 vault_backend: consul
 vault_backend_consul: vault_backend_consul.j2
 vault_backend_file: vault_backend_file.j2
+vault_backend_raft: vault_backend_raft.j2
 vault_backend_etcd: vault_backend_etcd.j2
 vault_backend_s3: vault_backend_s3.j2
 vault_backend_dynamodb: vault_backend_dynamodb.j2
@@ -74,6 +75,8 @@ vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
 vault_cluster_addr: "{{ vault_protocol }}://{{ vault_cluster_address }}"
 vault_api_addr: "{{ vault_protocol }}://{{ vault_redirect_address | default(hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address']) }}:{{ vault_port }}"
+
+vault_raft_node_id: "raft_node_1"
 
 vault_max_lease_ttl: "768h"
 vault_default_lease_ttl: "768h"

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -1,0 +1,4 @@
+storage "raft" {
+  path = "{{ vault_data_path }}"
+  node_id = "{{ vault_raft_node_id }}"
+}

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -1,13 +1,13 @@
 backend "raft" {
   path = "{{ vault_raft_data_path }}"
   node_id = "{{ vault_raft_node_id }}"
-  {% for server in groups['vault_raft_servers'] | difference([inventory_hostname]) %}
+  {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
-    leader_api_addr =  "https://{{ hostvars[server]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
-    leader_ca_cert = "{{ vault_tls_config_path }}/{{ hostvars[server]['vault_tls_ca_file'] }}"
-    leader_client_cert = "{{ vault_tls_config_path }}/{{ hostvars[server]['vault_tls_cert_file'] }}"
-    leader_client_key = "{{ vault_tls_config_path }}/{{ hostvars[server]['vault_tls_key_file'] }}"
+    leader_api_addr =  "{{ hostvars[server]['vault_api_addr'] }}"
+    leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
+    leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+    leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
   }
     {% else %}
   retry_join {

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -46,6 +46,8 @@ listener "tcp" {
   {% include vault_backend_dynamodb with context -%}
 {% elif vault_backend == 'mysql' -%}
   {% include vault_backend_mysql with context -%}
+{% elif vault_backend == 'raft' -%}
+  {% include vault_backend_raft with context -%}
 {% endif %}
 
 {% if vault_ui -%}


### PR DESCRIPTION
Hey there, I saw you had filed a PR with the ansible-community vault role for raft support and I had to make a couple changes to make it work for my use case.  Would you consider merging these into your PR?  Basically I just needed to change the following -

- Allow for the selection of the inventory group for the raft servers
- Get the API address from the dedicated host variable
- Use the backend tls variables for the raft client certs

These edits should all result in the same default behavior as your original PR but allow for finer grained control.  Also I went ahead and merged the upstream changes to remove the merge conflicts.